### PR TITLE
ExpressLRS - added LQ/RSSI on channels 15/16

### DIFF
--- a/src/main/rx/expresslrs_common.h
+++ b/src/main/rx/expresslrs_common.h
@@ -49,9 +49,10 @@
 #define ELRS_RATE_MAX 4
 #define ELRS_RATE_DEFAULT 0
 
-#define ELRS_RSSI_LPF_CUTOFF_FREQ_HZ 0.1f
-#define ELRS_INTERVAL_S(interval) ((float)interval / (1000 * 1000))
-#define ELRS_TIMEOUT(interval) (interval + (interval >> 5))
+#define ELRS_MAX_CHANNELS 16
+#define ELRS_RSSI_CHANNEL 15
+#define ELRS_LQ_CHANNEL 14
+
 #define ELRS_CONFIG_CHECK_MS 200
 
 typedef enum {

--- a/src/main/rx/expresslrs_impl.h
+++ b/src/main/rx/expresslrs_impl.h
@@ -58,6 +58,7 @@ typedef struct elrsReceiver_s {
 
     int8_t rssi;
     int8_t snr;
+    int8_t rssiFiltered;
 
     uint8_t uplinkLQ;
     lqMode_e lqMode;

--- a/src/test/unit/rx_spi_expresslrs_unittest.cc
+++ b/src/test/unit/rx_spi_expresslrs_unittest.cc
@@ -243,11 +243,11 @@ TEST(RxSpiExpressLrsUnitTest, TestInitUnbound)
     receiver = empty;
     rxExpressLrsSpiConfigMutable()->hybridSwitches = false;
     expressLrsSpiInit(&injectedConfig, &config, &extiConfig);
-    EXPECT_EQ(12, config.channelCount);
+    EXPECT_EQ(16, config.channelCount);
     receiver = empty;
     rxExpressLrsSpiConfigMutable()->hybridSwitches = true;
     expressLrsSpiInit(&injectedConfig, &config, &extiConfig);
-    EXPECT_EQ(12, config.channelCount);
+    EXPECT_EQ(16, config.channelCount);
 }
 
 TEST(RxSpiExpressLrsUnitTest, TestInitBound)


### PR DESCRIPTION
Add feature to allow Air Unit/Caddx Vista units to display LQ in OSD; feature pulled from phobos-' repository and flight-tested on H7RF.